### PR TITLE
Support of oldApi parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following plugin properties are configurable:
 - `mavenRepoUsername` - The username for accessing the Maven repository.
 - `mavenRepoPassword` - The password for accessing the Maven repository.
 - `newApi` - The path of the API file with which the latest version will be compared to
+- `oldApi` - The path of the latest API file(if no `mavenRepoUrl` property defined) 
 - `groupId` - The groupId of the artifact. Defaults to `project.group`
 - `artifactId` - The artifactId. Defaults to `project.name`
 - `outputFilePath` - The output where the report will be generated. Defaults to `project.buildDir/swagger-brake`

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Gradle plugin for [Swagger Brake](https://github.com/redskap/swagger-brake).
 
 The plugin is building on Swagger Brake's latest artifact resolution feature to determine the so 
 called `old` version of the API thus it's mandatory to provide the repository URL which will be used
-to download the proper artifact.
+to download the proper artifact. If you want to skip the latest artifact resolution 
+you can use a path to the latest version of your API to compare.
 
 There are 2 properties which are mandatory for this reason:
-- `mavenRepoUrl`
+- `mavenRepoUrl` or `oldApi`
 - `newApi`
 
 An example project can be found [here](https://github.com/redskap/swagger-brake-example/tree/master/swagger-brake-gradle-example).

--- a/src/main/groovy/io/redskap/swagger/brake/gradle/SwaggerBrakeExtension.groovy
+++ b/src/main/groovy/io/redskap/swagger/brake/gradle/SwaggerBrakeExtension.groovy
@@ -10,6 +10,7 @@ class SwaggerBrakeExtension {
     private static final Logger logger = Logging.getLogger(SwaggerBrakeExtension)
 
     final Property<Object> newApi
+    final Property<Object> oldApi
     final Property<Object> mavenRepoUrl
     final Property<Object> groupId
     final Property<Object> artifactId
@@ -25,6 +26,7 @@ class SwaggerBrakeExtension {
 
     SwaggerBrakeExtension(Project project) {
         this.newApi = project.getObjects().property(Object)
+        this.oldApi = project.getObjects().property(Object)
         this.mavenRepoUrl = project.getObjects().property(Object)
         this.groupId = project.getObjects().property(Object)
         this.artifactId = project.getObjects().property(Object)
@@ -49,6 +51,11 @@ class SwaggerBrakeExtension {
         applyDefaultBetaApiExtensionName()
         applyDefaultApiFilename()
         applyTestMode()
+        applyDefaultOldApi()
+    }
+
+    private applyDefaultOldApi() {
+        this.oldApi.set("")
     }
 
     private applyDefaultBetaApiExtensionName() {

--- a/src/main/groovy/io/redskap/swagger/brake/gradle/SwaggerBrakePlugin.groovy
+++ b/src/main/groovy/io/redskap/swagger/brake/gradle/SwaggerBrakePlugin.groovy
@@ -17,6 +17,7 @@ class SwaggerBrakePlugin implements Plugin<Project>  {
         def checkBreakingChangesTask = project.tasks.create("checkBreakingChanges", CheckBreakingChangesTask) {
             mavenRepoUrl = extension.mavenRepoUrl
             newApi = extension.newApi
+            oldApi = extension.oldApi
             artifactId = extension.artifactId
             groupId = extension.groupId
             outputFilePath = extension.outputFilePath

--- a/src/main/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTask.groovy
+++ b/src/main/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTask.groovy
@@ -11,6 +11,8 @@ class CheckBreakingChangesTask extends DefaultTask {
     @Input
     final Property<Object> newApi = getProject().getObjects().property(Object)
     @Input
+    final Property<Object> oldApi = getProject().getObjects().property(Object)
+    @Input
     final Property<Object> mavenRepoUrl = getProject().getObjects().property(Object)
     @Input
     final Property<Object> groupId = getProject().getObjects().property(Object)
@@ -41,6 +43,7 @@ class CheckBreakingChangesTask extends DefaultTask {
     void performCheck() {
         def parameter = new CheckBreakingChangesTaskParameter()
         parameter.newApi = newApi.get().toString()
+        parameter.oldApi = oldApi.get().toString()
         parameter.mavenRepoUrl = mavenRepoUrl.get().toString()
         parameter.groupId = groupId.get().toString()
         parameter.artifactId = artifactId.get().toString()

--- a/src/main/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTaskParameter.groovy
+++ b/src/main/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTaskParameter.groovy
@@ -2,6 +2,7 @@ package io.redskap.swagger.brake.gradle.task
 
 class CheckBreakingChangesTaskParameter {
     String newApi
+    String oldApi
     String mavenRepoUrl
     String groupId
     String artifactId
@@ -17,6 +18,7 @@ class CheckBreakingChangesTaskParameter {
     String toString() {
         return "CheckBreakingChangesTaskParameter{" +
                 "newApi='" + newApi + '\'' +
+                ", oldApi='" + oldApi + '\'' +
                 ", mavenRepoUrl='" + mavenRepoUrl + '\'' +
                 ", groupId='" + groupId + '\'' +
                 ", artifactId='" + artifactId + '\'' +

--- a/src/main/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTaskParameterValidator.groovy
+++ b/src/main/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTaskParameterValidator.groovy
@@ -4,8 +4,9 @@ import org.apache.commons.lang3.StringUtils
 
 class CheckBreakingChangesTaskParameterValidator {
     void validate(CheckBreakingChangesTaskParameter parameter) {
-        if (StringUtils.isBlank(parameter.mavenRepoUrl)) {
-            throw new IllegalArgumentException("mavenRepoUrl must be set")
+        if (StringUtils.isBlank(parameter.mavenRepoUrl)
+                && StringUtils.isBlank(parameter.oldApi) ) {
+            throw new IllegalArgumentException("mavenRepoUrl or oldApi must be set")
         }
         if (StringUtils.isBlank(parameter.newApi)) {
             throw new IllegalArgumentException("newApi must be set")

--- a/src/main/groovy/io/redskap/swagger/brake/gradle/task/OptionsFactory.groovy
+++ b/src/main/groovy/io/redskap/swagger/brake/gradle/task/OptionsFactory.groovy
@@ -9,6 +9,7 @@ class OptionsFactory {
     static Options create(CheckBreakingChangesTaskParameter parameter) {
         Options options = new Options()
         options.setNewApiPath(parameter.newApi)
+        options.setOldApiPath(parameter.oldApi)
         options.setMavenRepoUrl(parameter.mavenRepoUrl)
         options.setGroupId(parameter.groupId)
         options.setArtifactId(parameter.artifactId)

--- a/src/test/groovy/io/redskap/swagger/brake/gradle/SwaggerBrakePluginTest.groovy
+++ b/src/test/groovy/io/redskap/swagger/brake/gradle/SwaggerBrakePluginTest.groovy
@@ -52,6 +52,7 @@ class SwaggerBrakePluginTest extends Specification {
         assert extension.outputFilePath.get().startsWith("${project.buildDir}/swagger-brake")
         assert extension.outputFormat.get() == 'HTML'
         assert extension.testModeEnabled.get() == false
+        assert extension.oldApi.get() == ''
     }
 
     def "Plugin properties can be set with simple strings"() {
@@ -68,6 +69,7 @@ class SwaggerBrakePluginTest extends Specification {
         def expectedOutputFormat = 'JSON'
         def expectedMavenRepoUsername = 'username'
         def expectedMavenRepoPassword = 'password'
+        def expectedOldApi = 'somethingOld'
 
         when:
         project.pluginManager.apply(SwaggerBrakePlugin)
@@ -80,6 +82,7 @@ class SwaggerBrakePluginTest extends Specification {
             outputFormat = expectedOutputFormat
             mavenRepoUsername = expectedMavenRepoUsername
             mavenRepoPassword = expectedMavenRepoPassword
+            oldApi = expectedOldApi
         }))
 
         then:
@@ -93,6 +96,7 @@ class SwaggerBrakePluginTest extends Specification {
         assert extension.outputFormat.get() == expectedOutputFormat
         assert extension.mavenRepoUsername.get() == expectedMavenRepoUsername
         assert extension.mavenRepoPassword.get() == expectedMavenRepoPassword
+        assert extension.oldApi.get() == expectedOldApi
     }
 
 
@@ -108,7 +112,7 @@ class SwaggerBrakePluginTest extends Specification {
         def expectedArtifactId = "${project.name}"
         def expectedOutputFilePath = "${project.buildDir}/swagger-brake/"
         def expectedOutputFormat = "JSON"
-
+        def expectedOldApi = "${project.buildDir}/swagger-old.json"
 
         when:
         project.pluginManager.apply(SwaggerBrakePlugin)
@@ -119,6 +123,7 @@ class SwaggerBrakePluginTest extends Specification {
             artifactId = expectedArtifactId
             outputFilePath = expectedOutputFilePath
             outputFormat = expectedOutputFormat
+            oldApi = expectedOldApi
         }))
 
         then:
@@ -130,5 +135,6 @@ class SwaggerBrakePluginTest extends Specification {
         assert extension.artifactId.get() == expectedArtifactId
         assert extension.outputFilePath.get() == expectedOutputFilePath
         assert extension.outputFormat.get() == expectedOutputFormat
+        assert extension.oldApi.get() == expectedOldApi
     }
 }

--- a/src/test/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTaskParameterValidatorTest.groovy
+++ b/src/test/groovy/io/redskap/swagger/brake/gradle/task/CheckBreakingChangesTaskParameterValidatorTest.groovy
@@ -22,10 +22,11 @@ class CheckBreakingChangesTaskParameterValidatorTest extends Specification {
         assert e.message.contains('mavenRepoUrl')
     }
 
-    def "validate throws exception when mavenRepoUrl is empty"() {
+    def "validate throws exception when mavenRepoUrl or oldApi are empty"() {
         given:
         def parameter = new CheckBreakingChangesTaskParameter()
         parameter.mavenRepoUrl = ""
+        parameter.oldApi = ""
         parameter.newApi = "newApi"
         parameter.artifactId = "artifactId"
         parameter.groupId = "groupId"
@@ -37,7 +38,7 @@ class CheckBreakingChangesTaskParameterValidatorTest extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        assert e.message.contains('mavenRepoUrl')
+        assert e.message.contains('mavenRepoUrl or oldApi')
     }
 
     def "validate throws exception when newApi is null"() {


### PR DESCRIPTION
We would like to avoid going to the Maven repository for latest swagger contract instead using file to file compare like the CLI does by default.